### PR TITLE
Auto restart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,3 +26,4 @@ RUN mkdir -p /etc/prom-conf/
 
 CMD /usr/bin/confd -onetime -backend rancher -prefix /latest
 
+CMD ["/usr/bin/confd", "-backend", "rancher", "-interval", "30", "-prefix", "/latest"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Ed Marshall (ed.marshall@infinityworks.com)
 
 COPY confd/tmpl/* /etc/confd/templates/
 COPY confd/toml/* /etc/confd/conf.d/
+COPY scripts/restart-prometheus /restart-prometheus
 
 # Install compile and install confd
 ENV CONFD_VERSION=v0.11.0 GOMAXPROCS=2 \
@@ -11,7 +12,7 @@ ENV CONFD_VERSION=v0.11.0 GOMAXPROCS=2 \
     GOPATH=/opt/src \
     GOBIN=/gopath/bin
 
-RUN apk add --update go git gcc musl-dev \
+RUN apk add --update docker go git gcc musl-dev \
   && mkdir -p /opt/src; cd /opt/src \
   && git clone -b "$CONFD_VERSION" https://github.com/kelseyhightower/confd.git \
   && cd $GOPATH/confd/src/github.com/kelseyhightower/confd \
@@ -24,6 +25,8 @@ RUN apk add --update go git gcc musl-dev \
 
 RUN mkdir -p /etc/prom-conf/
 
-CMD /usr/bin/confd -onetime -backend rancher -prefix /latest
+RUN chmod u+x /restart-prometheus
+
+ENV PROMETHEUS_IMAGE_NAME="prom/prometheus"
 
 CMD ["/usr/bin/confd", "-backend", "rancher", "-interval", "30", "-prefix", "/latest"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Prometheus Config
 
-Simple container designed to populate prometheus configuration using confd, when deployed as part of the Prometheus catalog entry in Rancher. 
+Simple container designed to populate prometheus configuration using confd, when deployed as part of the Prometheus catalog entry in Rancher.
+
+## Auto-reload
+
+This container can auto-reload Prometheus when the config updates. To do this, you need to volume mount the Docker socket to `/var/run/docker.sock`. By default it will look for a container running the "prom/prometheus" image, but this can be overriden with an environment variable `PROMETHEUS_IMAGE_NAME`.

--- a/confd/toml/prometheus.yml.toml
+++ b/confd/toml/prometheus.yml.toml
@@ -4,3 +4,4 @@ dest = "/etc/prom-conf/prometheus.yml"
 keys = [
     "/hosts",
 ]
+reload_cmd = "/restart-prometheus"

--- a/scripts/restart-prometheus
+++ b/scripts/restart-prometheus
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+RESTART_NAME=$PROMETHEUS_IMAGE_NAME
+
+if [ -z $RESTART_NAME ]; then
+    exit 0
+fi
+
+if ! type "docker" > /dev/null; then
+  echo Docker not available, cannot restart Prometheus
+  exit 0
+fi
+
+if [ ! -S "/var/run/docker.sock" ]; then
+  echo Docker volume not mounted, cannot restart Prometheus
+  exit 0
+fi
+
+PROM_CONTAINER_ID=$(docker ps | grep "$RESTART_NAME" | cut -d ' ' -f1)
+
+if [ -z $PROM_CONTAINER_ID ]; then
+    echo Could not find Prometheus container with image $RESTART_NAME, cannot restart Prometheus
+    exit 0
+fi
+
+echo Restarting Prometheus at container ID: $PROM_CONTAINER_ID
+docker kill --signal "SIGHUP" $PROM_CONTAINER_ID
+echo Restart signal sent


### PR DESCRIPTION
This patch will cause Prometheus to auto-reload the config after an update.

The only annoyance I've found is that if you're using Grafana as a dashboard, hosts won't be added or removed dynamically - you need to do a full refresh of the page.

This will only work with the Rancher Prometheus community catalogue if we can get their docker-compose for prom-conf adjusted to:
1. Remove the overridden CMD
2. Volume map the Docker socket

Here is my adjusted docker-compose for reference:
```
prom-conf:
  labels:
    io.rancher.container.pull_image: always
    io.rancher.service.hash: 78356446345b77506204abd398df0ba04f744aee
  tty: true
  image: my-prom-conf
  links:
  - node-exporter:node-exporter
  volumes:
  - /etc/prom-conf/
  - /var/run/docker.sock:/var/run/docker.sock
```